### PR TITLE
Stop vim-historic overwritting my git commits with "Backup" message

### DIFF
--- a/plugin/vim-historic.vim
+++ b/plugin/vim-historic.vim
@@ -26,6 +26,9 @@ endif
 let s:installPath = expand("<sfile>:p:h")
 
 function! s:backup(filepath)
+    if exists('b:noBackups')
+         return
+    endif
 	:let output = system("sh " . s:installPath . "/../bin/backup.sh " . g:historicBackupRepoLocation . " " . a:filepath)
 endfunction
 
@@ -50,5 +53,6 @@ command! HistoricCompare :call s:compareWithHistory(expand("%:p"))
 command! HistoricReplace :call s:replaceWithHistory(expand("%:p"))
 
 if g:historicBackupOnSave == 1
+    autocmd! Filetype gitcommit let b:noBackups=1
 	autocmd! BufWritePost * :HistoricBackup
 endif

--- a/plugin/vim-historic.vim
+++ b/plugin/vim-historic.vim
@@ -26,9 +26,9 @@ endif
 let s:installPath = expand("<sfile>:p:h")
 
 function! s:backup(filepath)
-    if exists('b:noBackups')
-         return
-    endif
+	if exists('b:noBackups')
+		return
+	endif
 	:let output = system("sh " . s:installPath . "/../bin/backup.sh " . g:historicBackupRepoLocation . " " . a:filepath)
 endfunction
 
@@ -53,6 +53,6 @@ command! HistoricCompare :call s:compareWithHistory(expand("%:p"))
 command! HistoricReplace :call s:replaceWithHistory(expand("%:p"))
 
 if g:historicBackupOnSave == 1
-    autocmd! Filetype gitcommit let b:noBackups=1
+	autocmd! Filetype gitcommit let b:noBackups=1
 	autocmd! BufWritePost * :HistoricBackup
 endif


### PR DESCRIPTION
When editing git commit messages in VIM, vim-historic will override the saved commit message on disk with the commit message for the auto backup.

These changes disable vim-historic for git commit messages.